### PR TITLE
miner config to bt.axon

### DIFF
--- a/healthcare/base/miner.py
+++ b/healthcare/base/miner.py
@@ -43,7 +43,7 @@ class BaseMinerNeuron(BaseNeuron):
             )
 
         # The axon handles request processing, allowing validators to send this miner requests.
-        self.axon = bt.axon(wallet=self.wallet, port=self.config.axon.port)
+        self.axon = bt.axon(wallet=self.wallet, config=self.config)
 
         # Attach determiners which functions are called when servicing a request.
         bt.logging.info(f"Attaching forward function to miner axon.")


### PR DESCRIPTION
Ensure bittensor.axon() uses all the configurations for the miner when defined in pm2 start command.