### PR TITLE
One line per epoch rather than batch

### DIFF
--- a/healthcare/miner/model.py
+++ b/healthcare/miner/model.py
@@ -243,12 +243,14 @@ class ModelTrainer:
                     train_generator,
                     steps_per_epoch=len(train_df) // self.config.batch_size,  # Adjust based on your batch size
                     epochs=1,  # Number of epochs
-                    callbacks=[early_stopping, upload_callback]
+                    callbacks=[early_stopping, upload_callback],
+                    verbose=2
                 )
         else:
             history = model.fit(
                 train_generator,
                 steps_per_epoch=len(train_df) // self.config.batch_size,  # Adjust based on your batch size
                 epochs=self.config.num_epochs,  # Number of epochs
-                callbacks=[early_stopping, upload_callback]
+                callbacks=[early_stopping, upload_callback],
+                verbose=2
             )


### PR DESCRIPTION
Model.fit has a parameter, verbose, that is currently on 'auto' but should be 2 since logs are written to file via pm2. A line per epoch will result in much less clutter in logs and easier to gauge progress as an average is more useful than trying to estimate performance from per-batch loss. 