### PR TITLE
Add missing import

### DIFF
--- a/healthcare/base/neuron.py
+++ b/healthcare/base/neuron.py
@@ -17,6 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import copy
+import re
 import typing
 import tensorflow as tf
 import multiprocessing


### PR DESCRIPTION
re library is used when parsing gpu selection. But import is missing.